### PR TITLE
FIX: remove redundant functions, added progress info

### DIFF
--- a/World.py
+++ b/World.py
@@ -1,5 +1,4 @@
 import time
-import _World
 import numpy as np
 from Field import Field
 from constants import *
@@ -72,6 +71,8 @@ class World(object):
     def advanceTime(self):
         self.time += self.dt
         self.ts += 1
+        if(self.ts % 2 == 0):
+            print("Time step: {}; time: {}; dt: {}; {}".format(self.ts, self.time, self.dt, self.ts*100/self.num_ts))
         return self.ts<= self.num_ts
 
     # converts physical position to logical coordinate

--- a/alma.py
+++ b/alma.py
@@ -8,12 +8,11 @@ import numpy as np
 import Output
 from xml_io_lib import xread
 
-xread('fields_00100.vti')
 
 
 world = World(21, 21, 21)
 world.setExtents([-0.1,-0.1,0],[0.1,0.1,0.2])
-world.setTime(2e-10,10000)
+world.setTime(2e-10,10) # 10000
 
 sp1 = Species("O+", 16*AMU, QE, world)
 sp2 = Species("e-", ME, -1*QE, world)
@@ -49,8 +48,8 @@ while(world.advanceTime()):
     solver.computeEF()
 
     #screen and file output
-    Output.screenOutput(world,species)
-    Output.diagOutput(world,species)
+    #Output.screenOutput(world,species)
+    #Output.diagOutput(world,species)
     #
     # periodically write out results
     if world.getTs()%100 == 0 or world.isLastTimeStep():


### PR DESCRIPTION
Currently, I see the following statistics:
```
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       12   45.319    3.777   62.468    5.206 PotentialSolver.py:14(solve)
   938184   39.155    0.000   39.155    0.000 Field.py:44(gather)
     1152   15.058    0.013   18.189    0.016 debug_output.py:4(write_3D)
   860002    9.724    0.000    9.724    0.000 Field.py:23(scatter)
  1798186    6.443    0.000    6.443    0.000 World.py:79(XtoL)
       22    4.042    0.184    4.280    0.195 debug_output.py:17(writeParticles)
```